### PR TITLE
fix msrun log saving path when using SFS to auto resume training

### DIFF
--- a/tools/modelarts/README.md
+++ b/tools/modelarts/README.md
@@ -4,13 +4,22 @@
 
 MindSpore >= 2.3 supports using [`msrun`](https://www.mindspore.cn/tutorials/experts/zh-CN/master/parallel/msrun_launcher.html) to launch distributed training on ModelArts.
 
-Usage example:
+Usage:
 ```shell
 # $MA_JOB_DIR is the working dir of your training job on modelarts.
-python $MA_JOB_DIR/mindone/tools/modelarts/msrun/msrun.py [WORK_DIR] [SCRIPT_NAME]
+export output_path=[YOUR_OUTPUT_PATH]  # should be an ABSOLUTE path
+python $MA_JOB_DIR/mindone/tools/modelarts/msrun/msrun.py [YOUR_WORK_DIR] [YOUR_SCRIPT_NAME]
+```
+
+Example:
+```shell
+export output_path=$MA_JOB_DIR/mindone/examples/opensora_hpcai/output
 python $MA_JOB_DIR/mindone/tools/modelarts/msrun/msrun.py mindone/examples/opensora_hpcai/scripts train.py
 ```
 
+⚠️ Note: 
+- `$output_path` should be an **ABSOLUTE** path.
+- if no `$output_path`, the msrun logs will be saved at the ModelArts default output directory: `/home/ma-user/modelarts/outputs/output_path_0/`.
 
 ## Launch with rank table
 Refer to [here](https://support.huaweicloud.com/bestpractice-modelarts/develop-modelarts-0120.html).

--- a/tools/modelarts/msrun/run_train_modelarts.sh
+++ b/tools/modelarts/msrun/run_train_modelarts.sh
@@ -37,9 +37,17 @@ unset RANK_ID
 # 	msrun --worker_num=$RANK_SIZE --local_worker_num=8  --master_addr=$master_addr --node_rank=$node_rank --log_dir=/home/ma-user/modelarts/user-job-dir/device --join=False /home/ma-user/modelarts/user-job-dir/${work_dir}/run_mindformer.py $@
 # fi
 
+
+if [ -z "${output_path}" ]; then
+    log_root_dir="/home/ma-user/modelarts/outputs/output_path_0"  # no $output_path , set to ModelArts default output directory
+else
+    log_root_dir="${output_path}"
+fi
+
 current=`date "+%Y-%m-%dT%H-%M-%S"`
-log_dir=/home/ma-user/modelarts/outputs/output_path_0/${current}_msrun_log
+log_dir=${log_root_dir}/${current}_msrun_log
 mkdir -p $log_dir
+echo "msrun logs will be saved at: ${log_dir}"
 
 msrun --bind_core=True --worker_num=$(($VC_WORKER_NUM*8)) --local_worker_num=8  --master_addr=$master_addr --node_rank=$node_rank --log_dir=$log_dir --join=False /home/ma-user/modelarts/user-job-dir/${work_dir}/${script_name} $@
 


### PR DESCRIPTION
# What does this PR do?
This PR allows users to set msrun log saving dir mannually by `export output_path=[YOUR_OUTPUT_PATH]`. Adapt for using SFS to auto resume training.

If no $output_path, msrun logs will be saved at ModelArts default output dir: `/home/ma-user/modelarts/outputs/output_path_0`.


